### PR TITLE
Specify more exact dependency constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "saschagrunert/path", branch = "master", service = "gi
 
 [dependencies]
 fnv = "1"
-linked-hash-map = "0"
-log = "0"
+linked-hash-map = "0.5"
+log = "0.3"
 mowl = "1"
-time = "0"
+time = "0.1"


### PR DESCRIPTION
This fixes compile errors when building against incompatible versions of the `log` crate.